### PR TITLE
Peer reset connection error should not be treated as an error

### DIFF
--- a/platform/socket_extend.c
+++ b/platform/socket_extend.c
@@ -136,6 +136,8 @@ int recvfrom_extend_voidptr(SOCKET s, void* buf, int len, int flags, struct sock
 		errno = WSAGetLastError();
 		if (errno == WSAEWOULDBLOCK)
 			errno = EAGAIN;
+		if (errno == WSAECONNRESET)
+			errno = EAGAIN;
 	}
 	return ret;
 }


### PR DESCRIPTION
UDP server been closed incorrectly when peer socket reset its connection.