### PR TITLE
增加mingw64编译环境支持，以编译64位skynet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,15 @@ PLATFORM_INC ?= platform
 CFLAGS := -g -O2 -Wall -I$(PLATFORM_INC) -I$(LUA_INC) $(MYCFLAGS)
 # CFLAGS += -DUSE_PTHREAD_LOCK
 
+# Env arch bits check
+MACHINE_ARCH_INFO="`ls /mingw/lib/gcc/`"
+MACHINE_ARCH_IS_64BIT=$(if $(shell echo "${MACHINE_ARCH_INFO}" | grep '64'),TRUE,FALSE)
+
 # link
-LDFLAGS := -llua53 -lplatform -lpthread -lws2_32 -L$(SKYNET_BUILD_PATH)
+LDFLAGS := -llua53 -lplatform -lpthread -lws2_32 -lpsapi -L$(SKYNET_BUILD_PATH)
+ifeq ($(MACHINE_ARCH_IS_64BIT),TRUE)
+  LDFLAGS += -ldl -lpsapi
+endif
 SHARED := --shared
 EXPORT := -Wl,-E
 SHAREDLDFLAGS := -llua53 -lskynet -lplatform -lws2_32 -L$(SKYNET_BUILD_PATH)
@@ -61,7 +68,7 @@ SKYNET_EXE_SRC = skynet_main.c
 SKYNET_SRC = skynet_handle.c skynet_module.c skynet_mq.c \
   skynet_server.c skynet_start.c skynet_timer.c skynet_error.c \
   skynet_harbor.c skynet_env.c skynet_monitor.c skynet_socket.c socket_server.c \
-  malloc_hook.c skynet_daemon.c skynet_log.c
+  malloc_hook.c skynet_daemon.c skynet_log.c skynet_condition.c
 
 $(SKYNET_BUILD_PATH)/platform.dll : platform/platform.c platform/epoll.c platform/socket_poll.c platform/socket_extend.c
 	$(CC) $(CFLAGS) $(SHARED) $^ -lws2_32 -lwsock32 -o $@ -DDONOT_USE_IO_EXTEND -DFD_SETSIZE=1024

--- a/platform/platform.h
+++ b/platform/platform.h
@@ -1,6 +1,11 @@
 #ifndef PLATFORM_H
 #define PLATFORM_H
 
+#if (defined(__x86_64__) || defined(_M_X64)) && !defined(_POSIX)
+#define _POSIX
+#define sigset_t _sigset_t
+#endif
+
 #include "sys/socket.h"
 #include <unistd.h>
 #include <stdbool.h>
@@ -24,7 +29,10 @@ int sigaction(int sig, const struct sigaction *act, struct sigaction *oact);
 
 char *strsep(char **stringp, const char *delim);
 
+#if !defined(__x86_64__) && !defined(_M_X64)
 enum { CLOCK_THREAD_CPUTIME_ID, CLOCK_REALTIME, CLOCK_MONOTONIC };
+#endif
+
 int clock_gettime(int what, struct timespec *ti);
 
 enum { LOCK_EX, LOCK_NB };
@@ -62,26 +70,33 @@ int sp_add(poll_fd fd, int sock, void *ud);
 void sp_del(poll_fd fd, int sock);
 void sp_write(poll_fd, int sock, void *ud, bool enable);
 int sp_wait(poll_fd, struct event *e, int max);
-void sp_nonblocking(int sock);
 
+void sp_nonblocking(int sock);
+int newsocket_extend(int af, int type, int protocol);
 int write_extend_socket(int fd, const void *buffer, size_t sz);
 int read_extend_socket(int fd, void *buffer, size_t sz);
 int close_extend_socket(int fd);
 int pipe_socket(int fd[2]);
-int connect_extend_errno(SOCKET s, const struct sockaddr* name, int namelen);
+int bind_extend_socket(SOCKET fd, const struct sockaddr *name, int namelen);
+int listen_extend_socket(SOCKET s, int backlog);
+int accept_extend_socket(SOCKET s, struct sockaddr *addr, int *addrlen);
+int connect_extend_socket(SOCKET s, const struct sockaddr FAR *name, int namelen);
 int send_extend_errno(SOCKET s, const char* buffer, int sz, int flag);
-int recv_extend_errno(SOCKET s, char* buffer, int sz, int flag);
 int recv_extend_errno(SOCKET s, char* buffer, int sz, int flag);
 int getsockopt_extend_voidptr(SOCKET s, int level, int optname, void* optval, int* optlen);
 int setsockopt_extend_voidptr(SOCKET s, int level, int optname, const void* optval, int optlen);
 int recvfrom_extend_voidptr(SOCKET s, void* buf, int len, int flags, struct sockaddr* from, int* fromlen);
 
 #ifndef DONOT_USE_IO_EXTEND
+#define socket(af, type, protocol) newsocket_extend(af, type, protocol)
 #define write(fd, ptr, sz) write_extend_socket(fd, ptr, sz)
 #define read(fd, ptr, sz)  read_extend_socket(fd, ptr, sz)
 #define close(fd) close_extend_socket(fd)
 #define pipe(fd) pipe_socket(fd)
-#define connect(s, name, namelen) connect_extend_errno(s, name, namelen)
+#define bind(s, name, namelen) bind_extend_socket(s, name, namelen)
+#define listen(s, backlog) listen_extend_socket(s, backlog)
+#define accept(s, addr, addrlen) accept_extend_socket(s, addr, addrlen)
+#define connect(s, name, namelen) connect_extend_socket(s, name, namelen)
 #define send(s, buffer, sz, flag) send_extend_errno(s, buffer, sz, flag)
 #define recv(s, buffer, sz, flag) recv_extend_errno(s, buffer, sz, flag)
 #define getsockopt(s, level, optname, optval, optlen) getsockopt_extend_voidptr(s, level, optname, optval, optlen)

--- a/platform/skynet_condition.c
+++ b/platform/skynet_condition.c
@@ -1,0 +1,140 @@
+#include "skynet_condition.h"
+
+#if __X86_64__ || _M_X64
+
+int skynet_cond_init(skynet_cond_t *cond, void *attr)
+{
+    cond->waiters_blocked = 0;
+    cond->waiters_gone = 0;
+    cond->waiters_to_unblock = 0;
+
+    cond->block_lock = CreateSemaphoreW(NULL, 1, LONG_MAX, NULL);
+    cond->block_queue = CreateSemaphoreW(NULL, 0, LONG_MAX, NULL);
+
+    InitializeCriticalSectionAndSpinCount(&cond->unblock_lock, 4000);
+
+    return 0;
+}
+
+int skynet_cond_wait(skynet_cond_t *cond, pthread_mutex_t *mutex)
+{
+    int signals_was_left = 0;
+    WaitForSingleObject(cond->block_lock, INFINITE);
+    ++cond->waiters_blocked;
+    ReleaseSemaphore(cond->block_lock, 1, NULL);
+
+#ifdef _MSC_VER
+ #pragma inline_depth(0)
+#endif
+
+    pthread_mutex_unlock(mutex);
+    WaitForSingleObject(cond->block_queue, INFINITE);
+
+    EnterCriticalSection(&cond->unblock_lock);
+    if ((signals_was_left = cond->waiters_to_unblock) != 0)
+    {
+        --cond->waiters_to_unblock;
+    }
+    else if (cond->waiters_blocked == ++cond->waiters_gone)
+    {
+        WaitForSingleObject(cond->block_lock, INFINITE);
+        cond->waiters_blocked -= cond->waiters_gone;
+        ReleaseSemaphore(cond->block_lock, 1, NULL);
+
+        cond->waiters_gone = 0;
+    }
+
+    LeaveCriticalSection(&cond->unblock_lock);
+    if (signals_was_left == 1)
+    {
+        ReleaseSemaphore(cond->block_lock, 1, NULL);
+    }
+
+    pthread_mutex_lock(mutex);
+
+#ifdef _MSC_VER
+ #pragma inline_depth()
+#endif
+
+    return 0;
+}
+
+static int _skynet_cond_signal(skynet_cond_t *cond, bool signal_all)
+{
+    int signals_to_issue = 0;
+    EnterCriticalSection(&cond->unblock_lock);
+    if (cond->waiters_to_unblock != 0)
+    {
+        if (cond->waiters_blocked == 0)
+        {
+            LeaveCriticalSection(&cond->unblock_lock);
+            return 0;
+        }
+        
+        if (signal_all)
+        {
+            cond->waiters_to_unblock += (signals_to_issue = cond->waiters_blocked);
+            cond->waiters_blocked = 0;
+        }
+        else
+        {
+            signals_to_issue = 1;
+            ++ cond->waiters_to_unblock;
+            -- cond->waiters_blocked;
+        }
+    }
+    else if (cond->waiters_blocked > cond->waiters_gone)
+    {
+        WaitForSingleObject(cond->block_lock, INFINITE);
+        if (cond->waiters_gone != 0)
+        {
+            cond->waiters_blocked -= cond->waiters_gone;
+            cond->waiters_gone = 0;
+        }
+
+        if (signal_all)
+        {
+            signals_to_issue = cond->waiters_to_unblock = cond->waiters_blocked;
+            cond->waiters_blocked = 0;
+        }
+        else
+        {
+            signals_to_issue = cond->waiters_to_unblock = 1;
+            -- cond->waiters_blocked;
+        }
+    }
+    else
+    {
+        LeaveCriticalSection(&cond->unblock_lock);
+        return 0;
+    }
+
+    LeaveCriticalSection(&cond->unblock_lock);
+    ReleaseSemaphore(cond->block_queue, signals_to_issue, NULL);
+
+    return 0;
+}
+
+int skynet_cond_signal(skynet_cond_t *cond)
+{
+    return _skynet_cond_signal(cond, false);
+}
+
+int skynet_cond_broadcast(skynet_cond_t *cond)
+{
+    return _skynet_cond_signal(cond, true);
+}
+
+int skynet_cond_destroy(skynet_cond_t *cond)
+{
+    CloseHandle(cond->block_queue);
+    cond->block_queue = NULL;
+
+    CloseHandle(cond->block_lock);
+    cond->block_lock = NULL;
+    DeleteCriticalSection(&cond->unblock_lock);
+
+    return 0;
+}
+
+#endif // __x86_64__ || _M_X64

--- a/platform/skynet_condition.h
+++ b/platform/skynet_condition.h
@@ -1,0 +1,39 @@
+#ifndef SKYNET_CONDITION_H
+#define SKYNET_CONDITION_H
+
+#include <pthread.h>
+
+#if __x86_64 || _M_X64
+
+#include <windows.h>
+
+typedef struct 
+{
+    long waiters_blocked;   // Number of threads blocked.
+    long waiters_gone;      // Number of threads timed out.
+    long waiters_to_unblock; // Number of threads to unblock.
+
+    HANDLE block_lock;  // Semaphore that guards access to waiters blocked count/block queue.
+    HANDLE block_queue; // Queue up threads waiting for the condition to be become signalled.
+    CRITICAL_SECTION unblock_lock; // Mutex that guards access to waiters (to)unblock(ed) counts.
+} skynet_cond_t;
+
+extern int skynet_cond_init(skynet_cond_t *cond, void *attr);
+extern int skynet_cond_wait(skynet_cond_t *cond, pthread_mutex_t *mutex);
+extern int skynet_cond_signal(skynet_cond_t *cond);
+extern int skynet_cond_broadcast(skynet_cond_t *cond);
+extern int skynet_cond_destroy(skynet_cond_t *cond);
+
+#else // 32bit mode
+
+#define skynet_cond_t pthread_cond_t
+
+#define skynet_cond_init pthread_cond_init
+#define skynet_cond_wait pthread_cond_wait
+#define skynet_cond_signal pthread_cond_signal
+#define skynet_cond_broadcast pthread_cond_broadcast
+#define skynet_cond_destroy pthread_cond_destroy
+
+#endif
+
+#endif // !SKYNET_CONDITION_H

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,10 +1,28 @@
 #!/bin/sh
 
-ln -s -f skynet/3rd/ 3rd
-ln -s skynet/examples/ examples 
-ln -s skynet/lualib/ lualib  
-ln -s skynet/lualib-src/ lualib-src  
-ln -s skynet/service/ service 
-ln -s skynet/service-src/ service-src  
-ln -s skynet/skynet-src/ skynet-src 
-ln -s skynet/test/ test
+# link some skynet directories
+need_link_dirs=(3rd examples lualib lualib-src service service-src skynet-src test)
+for d in ${need_link_dirs[@]}; do
+    rm -rf ${d}
+    ln -s skynet/${d} ${d}
+done
+
+
+# modify skynet_start.c
+SKYNET_START_FILE="skynet-src/skynet_start.c"
+
+cp -rf platform/skynet_condition.c skynet-src/
+
+# insert '#include "skynet_condition.h"' statement(sed insert new line after/before match not supported in mingw env)
+awk '/^#include +<pthread.h>/{print "#include \"skynet_condition.h\"";}1' ${SKYNET_START_FILE} > ${SKYNET_START_FILE}.new 
+cp -f ${SKYNET_START_FILE}.new ${SKYNET_START_FILE}
+
+# update all pthread_cond_xxxx type&methods to skynet_cond_xxxx type&methods
+sed -e 's/pthread_cond_t/skynet_cond_t/g' ${SKYNET_START_FILE} > ${SKYNET_START_FILE}.new && cp -f ${SKYNET_START_FILE}.new ${SKYNET_START_FILE}
+sed -e 's/pthread_cond_init/skynet_cond_init/g' ${SKYNET_START_FILE} > ${SKYNET_START_FILE}.new && cp -f ${SKYNET_START_FILE}.new ${SKYNET_START_FILE}
+sed -e 's/pthread_cond_wait/skynet_cond_wait/g' ${SKYNET_START_FILE} > ${SKYNET_START_FILE}.new && cp -f ${SKYNET_START_FILE}.new ${SKYNET_START_FILE}
+sed -e 's/pthread_cond_signal/skynet_cond_signal/g' ${SKYNET_START_FILE} > ${SKYNET_START_FILE}.new && cp -f ${SKYNET_START_FILE}.new ${SKYNET_START_FILE}
+sed -e 's/pthread_cond_broadcast/skynet_cond_broadcast/g' ${SKYNET_START_FILE} > ${SKYNET_START_FILE}.new && cp -f ${SKYNET_START_FILE}.new ${SKYNET_START_FILE}
+sed -e 's/pthread_cond_destroy/skynet_cond_destroy/g' ${SKYNET_START_FILE} > ${SKYNET_START_FILE}.new && cp -f ${SKYNET_START_FILE}.new ${SKYNET_START_FILE}
+rm -f "${SKYNET_START_FILE}".new
+


### PR DESCRIPTION
集中于以下三个修改
*所有修改都已在自身的mingw32、mingw64环境中测试通过*
---
### epoll增加64位兼容：
epoll.h/epoll.c：epoll_fd实现在32位下为将epoll_fd *强转为int返回，在64位下，会导致错误，代码中也有`assert(sizeof(struct epoll_fd *) <= sizeof(int))`判断，新的修改为增加一个映射数组，只在64位下启用，在epoll_create返回前，将epoll_fd放入到数组，只返回数组下标，即一个int类型。

---
### 编译Makefile修改：
64位的mingw环境为直接已经编译好的环境，编译时，发现缺少dlfcn动态库头文件及库文件，使用github中的三方封装完成，[dlfcn-win32](https://github.com/dlfcn-win32/dlfcn-win32.git)，直接在mingw64环境中`./configure && make && make install`即可。
修改后的Makefile会自动判别是编译64位的skynet还是32位的skynet，从而决定是否额外链接dl库及psapi库。

---
### pthread_cond BUG修复：
64位的mingw环境中自带的libwinpthread库存在pthread_cond_signal死锁问题，网上无法找到比较新的代替品，使用自身库中的condition实现替代，在platform/skynet_condition.h platform/skynet_condition.c中实现，在32位下，不使用此实现，只在64位下使用这两个文件中的代码定义实现pthread_cond功能，新的cond类型为skynet_cond_t，对应的函数为skynet_cond_xxxx()，这个会修改skynet_start.c文件，已经在prepare.sh中自动完成注入及修改，不需要使用者关心有此修补包存在。

---
### prepare.sh修改：
原有的`ln -f xxx xxx`的重复操作修改为直接定义一个数组，for each完成ln操作，增加对skynet_start.c代码的自动修改、注入代码（第三点有说明）。